### PR TITLE
Correctly handle whitespace in folder name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Jekyll-Bliss: The Answer to Slow Build Times in Jekyll
 ---
 
+NOTE: FUTURE DEVELOPMENT WILL HAPPEN [ON GITLAB](https://gitlab.com/dougbeney/Jekyll-Bliss). THANK YOU.
+
 # Introduction
 
 Jekyll is my favorite static site generator because it is very non-opinionated. The folder structure is super simplistic and feels natural.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Jekyll-Bliss: The Answer to Slow Build Times in Jekyll
 ---
 
-NOTE: FUTURE DEVELOPMENT WILL HAPPEN [ON GITLAB](https://gitlab.com/dougbeney/Jekyll-Bliss). THANK YOU.
+# **NOTE: FUTURE DEVELOPMENT WILL HAPPEN [ON GITLAB](https://gitlab.com/dougbeney/Jekyll-Bliss). THANK YOU.**
 
 # Introduction
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,26 @@ jekyll-bliss:
 
 **Note:** If you enable `livereload`, `watch` will automatically be enabled too.
 
+## Deploying to Various Platforms
+
+### Netlify
+
+First, create a file called `Makefile` with the following content:
+
+```
+netlify:
+  npm install jekyll-bliss -g
+  bliss build
+```
+
+Now, log into Netlify, go into your site settings, go to the "Build & deploy" section. Now, under "Deploy settings" click "Edit settings" and finally change your build command to `make netlify`.
+
+You're all set! Enjoy!
+
+### Github Pages
+
+I recommend checking out this [insightful thread](https://github.com/DougBeney/jekyll-pug/issues/14) for a viable solution to use Jekyll-Bliss with Github Pages. Ortonomy explains his solution later on in the thread.
+
 # Results from using Jekyll-Bliss
 
 I gave Jekyll-Bliss a test on my personal site, [dougie.io](https://dougie.io)

--- a/parts/tasks.js
+++ b/parts/tasks.js
@@ -84,7 +84,7 @@ module.exports = function(data, functions) {
 			}, function done(result) {
 				module.jekyll_build_in_progress = true
 				// Build Jekyll
-				var cmd_dest = ' --destination '+functions.getdestfolder()
+				var cmd_dest = ' --destination "'+functions.getdestfolder()+'"'
 				var cmd_bundle = (fs.existsSync(functions.getpath('Gemfile'))) ? "bundle exec " : ""
 				var cmd = cmd_bundle+'jekyll build'+cmd_dest
 				functions.DEBUG('Using this Jekyll build command:\n' + cmd)


### PR DESCRIPTION
If the path to your Jekyll project contains a space (e.g. `/home/user/my projects/jekyll`), the build fails, as it is trying to build to `/home/user/my`. By adding quotes around the destination, you prevent this.